### PR TITLE
Get latest ami dynamically and set it as default for managed node groups

### DIFF
--- a/Clusters/AWS/data.tf
+++ b/Clusters/AWS/data.tf
@@ -7,3 +7,7 @@ data "aws_eks_cluster_auth" "cluster" {
 }
 
 data "aws_caller_identity" "current" {}
+
+data "aws_ssm_parameter" "latest_ami_release_version" {
+   name     = "/aws/service/eks/optimized-ami/${var.cluster_version}/amazon-linux-2/recommended/image_id"
+}

--- a/Clusters/AWS/eks-cluster.tf
+++ b/Clusters/AWS/eks-cluster.tf
@@ -69,4 +69,8 @@ module "eks" {
       ]
     }
   ]
+
+  eks_managed_node_group_defaults = {
+    ami_release_version = data.aws_ssm_parameter.latest_ami_release_version.value
+  }
 }


### PR DESCRIPTION
### Task
Assume the EKS cluster has been provisioned using the terraform-aws-eks module.
Provide a code snippet showing how you would fetch the latest AMI release version
available for Kubernetes version 1.27 to populate this variable of the module.

## Source
Based of the [official documentation](https://docs.aws.amazon.com/eks/latest/userguide/retrieve-ami-id.html), I've added the terraform resource ```data.aws_ssm_parameter.latest_ami_release_version``` to retrieve the latest AMI ID for the kubernetes version being installed (1.27 by default) and then used this value as a default value in the EKS module.

***Important note:*** This code is only for demonstrate how to fetch the latest AMI release version as requested by the task. This may actually not work if merged to main.